### PR TITLE
Fix: Only update parameters with valid gradients

### DIFF
--- a/pygrad/nn/optim.py
+++ b/pygrad/nn/optim.py
@@ -14,9 +14,10 @@ class Optimizer:
         self.params = tuple(params)
 
     def step(self):
+        params = [p for p in self.params if p.grad is not None]
         for hook in self.hooks:
             hook(params)
-        for param in self.params:
+        for param in params:
             self.step_one(param)
 
     def step_one(self, param):


### PR DESCRIPTION
Fixes #1 by calling `step_one()` only for parameters with valid (i.e. not `NoneType`) gradients.  